### PR TITLE
Update mycred-hook-woocommerce.php to check if array key is set

### DIFF
--- a/includes/hooks/external/mycred-hook-woocommerce.php
+++ b/includes/hooks/external/mycred-hook-woocommerce.php
@@ -421,7 +421,10 @@ if ( ! function_exists( 'mycred_get_woo_product_reward' ) ) :
 
 			// If the variation has no value set, but the parent box has a value set, enforce the parent value
 			// If the variation is set to zero however, it indicates we do not want to reward that variation
-			if ( $value == '' && $parent_reward_setup[ $point_type ] != '' && $parent_reward_setup[ $point_type ] != 0 )
+			if ( $value == '' && 
+			     isset( $parent_reward_setup[ $point_type ] ) &&  
+			     $parent_reward_setup[ $point_type ] != '' && 
+			     $parent_reward_setup[ $point_type ] != 0 )
 				$reward_setup[ $point_type ] = $parent_reward_setup[ $point_type ];
 
 		}


### PR DESCRIPTION
Resolves issue with a warning being written to Apache error log:

PHP Warning:  Undefined array key 0 in /bitnami/wordpress/wp-content/plugins/mycred/includes/hooks/external/mycred-hook-woocommerce.php on line 424

This warning has appeared over 40,000 times in our apache log, and would greatly appreciate this small code change to prevent the warning from being generated.

Thanks you
Dev Team
Western CPE