### PR TITLE
Check cached user history data is an array

### DIFF
--- a/addons/stats/includes/mycred-stats-functions.php
+++ b/addons/stats/includes/mycred-stats-functions.php
@@ -814,7 +814,7 @@ if ( ! function_exists( 'mycred_get_users_history_data' ) ) :
 		$stats_key = md5( $user_id . $point_type . $period . $number . $order );
 		$cache     = mycred_get_user_meta( $user_id, $point_type . '_stats', $stats_key );
 
-		if ( empty($cache) ) {
+		if ( empty($cache) || !is_array($cache) ) {
 
 			global $wpdb, $mycred_log_table;
 


### PR DESCRIPTION
Patch for issue #22 - Prevents corrupted cache from being used in getting user history